### PR TITLE
Update Patch_CompEquippable.cs

### DIFF
--- a/Source/VFECore/VFECore/HarmonyPatches/Patch_CompEquippable.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Patch_CompEquippable.cs
@@ -20,7 +20,7 @@ namespace VFECore
             public static void Postfix(CompEquippable __instance, ref IEnumerable<Command> __result)
             {
                 // Clear gizmos if parent is a shield and isn't off-hand - though the verb will still be usable
-                var pawn = __instance.PrimaryVerb.CasterPawn;
+                var pawn = __instance.PrimaryVerb?.CasterPawn;
                 if (pawn != null && pawn.equipment.Primary != __instance.parent)
                     __result = __result.Where(g => false);
             }


### PR DESCRIPTION
Fix for cases when a CompEquipable does not have a PrimaryVerb and leads to NullReferenceException.