### PR TITLE
Fix NRE when Pawn_EquipmentTracker::TryDropEquipment is skipped

### DIFF
--- a/Source/VFECore/VFECore/Utilities/VerbUtility.cs
+++ b/Source/VFECore/VFECore/Utilities/VerbUtility.cs
@@ -15,6 +15,11 @@ namespace VFECore
 
         public static void TryModifyThingsVerbs(ThingWithComps thing)
         {
+            if (thing == null)
+            {
+                return;
+            }
+
             DrawStatsReport_Patch.interruptWork = true;
             if (thing is Pawn pawn2)
             {


### PR DESCRIPTION
When a harpy from [SYR] Harpies is downed, trying to rescue it causes a null reference exception (which prevents it from being rescued).

The issue is that the Harpies mod patches `Pawn_EquipmentTracker::TryDropEquipment`. If the equipment is its lightning weapon the original method is skipped.
https://github.com/Syrchalis/Harpy/blob/5b2942830b3b81054f2bf4a118e2cd3a33445728/Source/HarmonyPatches.cs#L386-L399

When the original method is skipped the output variable `out ThingWithComps resultingEq` is left uninitialized.
Then the postfix patch in VFECore `TryDropEquipment_Patch` is called with `resultingEq` = `null`.