### PR TITLE
Reloading Adjustment

### DIFF
--- a/1.3/Defs/ThinkTreeDefs/Reloading.xml
+++ b/1.3/Defs/ThinkTreeDefs/Reloading.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <!-- Makes colonists reload from inventory PreMain -->
+  <ThinkTreeDef>
+    <defName>Reloading_AmmoReload_Colony</defName>
+    <insertTag>Humanlike_PreMain</insertTag>
+    <insertPriority>100</insertPriority>
+    <thinkRoot Class="ThinkNode_Priority">
+      <subNodes>
+        <li Class="ThinkNode_ConditionalColonist">
+          <subNodes>
+            <li Class="Reloading.JobGiver_ReloadFromInventory" />
+          </subNodes>
+        </li>
+      </subNodes>
+    </thinkRoot>
+  </ThinkTreeDef>
+
+</Defs>

--- a/1.3/Patches/Misc/Reloading.xml
+++ b/1.3/Patches/Misc/Reloading.xml
@@ -3,7 +3,6 @@
     <Operation Class="PatchOperationInsert">
         <xpath>/Defs/ThinkTreeDef[defName="MainColonistBehaviorCore"]/thinkRoot/subNodes/li/subNodes/li[@Class="JobGiver_Reload"]</xpath>
         <value>
-            <li Class="Reloading.JobGiver_ReloadFromInventory" />
             <li Class="Reloading.JobGiver_Reload" />
         </value>
     </Operation>


### PR DESCRIPTION
Moves JobGiver_ReloadFromInventory from MainColonistBehaviorCore to Humanlike_PreMain so colonist have higher priority for the job. As it's done now colonists will prioritize needs like eating, sleeping, and using the toilet, and with this change only emergency jobs such as starvation should come before ReloadFromInventory.