### PR TITLE
Added more options for CompRegeneration

### DIFF
--- a/Source/VFECore/AnimalBehaviours/Comps/CompProperties/CompProperties_Regeneration.cs
+++ b/Source/VFECore/AnimalBehaviours/Comps/CompProperties/CompProperties_Regeneration.cs
@@ -8,6 +8,8 @@ namespace AnimalBehaviours
         //A very simple class that regenerates wounds
 
         public int rateInTicks = 1000;
+        public float healAmount = 0.1f;
+        public bool healAll = true;
 
         public CompProperties_Regeneration()
         {

--- a/Source/VFECore/AnimalBehaviours/Comps/CompRegeneration.cs
+++ b/Source/VFECore/AnimalBehaviours/Comps/CompRegeneration.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 using System.Linq;
@@ -29,6 +30,22 @@ namespace AnimalBehaviours
             }
         }
 
+        protected float healAmount
+        {
+            get
+            {
+                return this.Props.healAmount;
+            }
+        }
+
+        protected bool healAll
+        {
+            get
+            {
+                return this.Props.healAll;
+            }
+        }
+
 
         public override void CompTick()
         {
@@ -42,12 +59,27 @@ namespace AnimalBehaviours
 
                     if (pawn.health != null)
                     {
-                        if (pawn.health.hediffSet.GetInjuriesTendable() != null && pawn.health.hediffSet.GetInjuriesTendable().Count<Hediff_Injury>() > 0)
+                        IEnumerable<Hediff_Injury> injuriesEnumerable = pawn.health.hediffSet.GetInjuriesTendable();
+
+                        if (injuriesEnumerable != null)
                         {
-                            foreach (Hediff_Injury injury in pawn.health.hediffSet.GetInjuriesTendable())
+                            Hediff_Injury[] injuries = injuriesEnumerable.ToArray();
+
+                            if (injuries.Any())
                             {
-                                injury.Severity = injury.Severity - 0.1f;
-                                break;
+                                if (healAll)
+                                {
+                                    foreach (Hediff_Injury injury in injuries)
+                                    {
+                                        injury.Severity = injury.Severity - healAmount;
+                                        break;
+                                    }
+                                }
+                                else
+                                {
+                                    Hediff_Injury injury = injuries.RandomElement();
+                                    injury.Severity = injury.Severity - healAmount;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Additionally removed multiple enumerations by using only a single call to GetInjuriesTendable and turning it into an array.

The new properties that were added have default values matching their behaviour before their addition, so any mods already using this comp will behave as it was before.

I've decided to make those changes as I'll need them in a project I'm working on. An alternative for me would be to re-implement this comp myself with the changes I need, but it seems pointless to do so as VEF already provides most of the functionality I need, and it might come in useful for other mod developers.

Also a reminder that the [wiki page](https://github.com/AndroidQuazar/VanillaExpandedFramework/wiki/Regeneration) will need an update to reflect those changes, assuming those changes are accepted.