### PR TITLE
Allow renaming drones

### DIFF
--- a/Languages/English/Keyed/Machines.xml
+++ b/Languages/English/Keyed/Machines.xml
@@ -24,5 +24,5 @@
   <VFEMechSetAreaDesc>Set the allowed area for all of this platform's associated machines.</VFEMechSetAreaDesc>
   <VFEMRideableMachineTip>This droid is rideable. People in a caravan will ride the fastest available animals/droids, improving the speed of the caravan as a whole.</VFEMRideableMachineTip>
 	<VFEM.CaravanMachineRanOutPower>{MACHINE_nameDef} ran out of power, and was left behind.</VFEM.CaravanMachineRanOutPower>
-
+  <VFEM.DroneGainsName>The drone's name is now {0}.</VFEM.DroneGainsName>
 </LanguageData>

--- a/Source/VFECore/VFECore.csproj
+++ b/Source/VFECore/VFECore.csproj
@@ -312,6 +312,8 @@
     <Compile Include="VFECore\HarmonyPatches\Def_SpecialDisplayStats_Patch.cs" />
     <Compile Include="Memes\PlaceWorkers\PlaceWorker_DisabledByMeme.cs" />
     <Compile Include="VFECore\Comps\HediffComps\HediffComp_Targeting.cs" />
+    <Compile Include="VFECore\Dialogs\Dialog_NameDrone.cs" />
+    <Compile Include="VFECore\HarmonyPatches\Mechanoids\MainTabWindow_Patches.cs" />
     <Compile Include="VFECore\HarmonyPatches\Stat_Patches.cs" />
     <Compile Include="VFECore\HarmonyPatches\MapGenerator_GenerateContentsIntoMap_Patch.cs" />
     <Compile Include="VFECore\HarmonyPatches\GenStep_Terrain_TerrainFrom_Patch.cs" />

--- a/Source/VFECore/VFECore/Dialogs/Dialog_NameDrone.cs
+++ b/Source/VFECore/VFECore/Dialogs/Dialog_NameDrone.cs
@@ -1,0 +1,26 @@
+using RimWorld;
+using Verse;
+using VFEMech;
+
+namespace VFECore
+{
+	// Dialog_NamePawn only supports persons or animals. Drones need a separate (but simpler) implementation.
+	public class Dialog_NameDrone : Dialog_Rename
+	{
+		private readonly Machine drone;
+
+		public Dialog_NameDrone(Machine pawn)
+		{
+			drone = pawn;
+			curName = drone.Name.ToStringShort;
+		}
+
+		protected override void SetName(string name)
+		{
+			drone.Name = new NameSingle(name);
+
+			Messages.Message("VFEM.DroneGainsName".Translate((NamedArgument)name), (Thing)drone,
+				MessageTypeDefOf.PositiveEvent, false);
+		}
+	}
+}

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MainTabWindow_Patches.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MainTabWindow_Patches.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using VFECore;
+using VFEMech;
+
+namespace VFE.Mechanoids.HarmonyPatches
+{
+	[HarmonyPatch(typeof(MainTabWindow_Inspect), nameof(MainTabWindow_Inspect.DoInspectPaneButtons))]
+	public static class MainTabWindow_Inspect_Renaming
+	{
+		/// Show a rename button in the inspect pane when a single drone is selected.
+		public static void Postfix(Rect rect, ref float lineEndWidth)
+		{
+			// Only functioning drones belonging to the player faction can be renamed.
+			if (Find.Selector.NumSelected != 1 || !(Find.Selector.SingleSelectedThing is Machine drone) ||
+			    drone.health.Dead || drone.Faction != Faction.OfPlayer)
+			{
+				return;
+			}
+
+			const float renameSize = 30f;
+			// See MainTabWindow_Inspect.DoInspectPaneButtons for the initial value of x.
+			float x = rect.width - 48f - renameSize;
+
+			Rect renameArea = new Rect(x, 0.0f, renameSize, renameSize);
+			TooltipHandler.TipRegionByKey(renameArea, "Rename");
+			if (Widgets.ButtonImage(renameArea, TexButton.Rename))
+			{
+				Find.WindowStack.Add(new Dialog_NameDrone(drone));
+			}
+
+			lineEndWidth += renameSize;
+		}
+	}
+}

--- a/Source/VFECore/VFECore/Pawns/Machine.cs
+++ b/Source/VFECore/VFECore/Pawns/Machine.cs
@@ -25,7 +25,13 @@ namespace VFEMech
                     this.drafter = new Pawn_DraftController(this);
                 }
             }
+
+            if (this.Faction == Faction.OfPlayer && this.Name == null)
+            {
+                this.Name = PawnBioAndNameGenerator.GeneratePawnName(this, NameStyle.Numeric);
+            }
         }
+
         public override void PostApplyDamage(DamageInfo dinfo, float totalDamageDealt)
         {
             base.PostApplyDamage(dinfo, totalDamageDealt);


### PR DESCRIPTION
Drones belonging to the player faction will get a defaulted numbered name after spawning, similar to the name animals get after being tamed or born. Machines in existing savegames before this feature was implemented will get a name after the game is loaded with a newer version of the framework.

A Rename button for drones has been added to the inspect pane, as shown in the screenshot below.

![PR](https://user-images.githubusercontent.com/3092211/171839220-198949a2-1b1e-4546-9376-2b18a63de60c.png)
