### PR TITLE
Fix toggleable animals errors when saved defs don't exist

### DIFF
--- a/Source/VFECore/AnimalBehaviours/Options/VanillaAnimalsExpanded_Settings.cs
+++ b/Source/VFECore/AnimalBehaviours/Options/VanillaAnimalsExpanded_Settings.cs
@@ -33,7 +33,7 @@ namespace AnimalBehaviours
         public void DoWindowContents(Rect inRect)
         {
 
-            List<string> keys = pawnSpawnStates.Keys.ToList().OrderByDescending(x => DefDatabase<ThingDef>.GetNamed(x).label).ToList();
+            List<string> keys = pawnSpawnStates.Keys.ToList().OrderByDescending(x => DefDatabase<ThingDef>.GetNamedSilentFail(x)?.label).ToList();
             Listing_Standard ls = new Listing_Standard();
             Rect rect = new Rect(inRect.x, inRect.y, inRect.width, inRect.height);
             Rect rect2 = new Rect(0f, 0f, inRect.width - 30f, keys.Count  * 24);

--- a/Source/VFECore/AnimalBehaviours/Options/VanillaAnimalsExpanded_SettingsController.cs
+++ b/Source/VFECore/AnimalBehaviours/Options/VanillaAnimalsExpanded_SettingsController.cs
@@ -47,7 +47,7 @@ namespace AnimalBehaviours
                 if (settings.pawnSpawnStates == null) settings.pawnSpawnStates = new Dictionary<string, bool>();
                 foreach (string defName in toggleablespawndef.toggleablePawns)
                 {
-                    if (!settings.pawnSpawnStates.ContainsKey(defName))
+                    if (!settings.pawnSpawnStates.ContainsKey(defName) && DefDatabase<ThingDef>.GetNamedSilentFail(defName) != null)
                     {
                         settings.pawnSpawnStates[defName] = false;
                     }


### PR DESCRIPTION
For example, if I had a mod with toggleable animals feature, and then removed it - it would cause the settings window for toggleable animals to constantly show errors and throw exceptions about it being unable to find the animals.

This should fix that.