### PR TITLE
added null check for currentColor

### DIFF
--- a/Source/VFECore/Furniture/Comps/CompGlowerExtended.cs
+++ b/Source/VFECore/Furniture/Comps/CompGlowerExtended.cs
@@ -46,7 +46,7 @@ namespace VanillaFurnitureExpanded
         public CompProperties_GlowerExtended Props => (CompProperties_GlowerExtended)props;
         public override string TransformLabel(string label)
         {
-            if (!currentColor.colorLabel.NullOrEmpty())
+            if (!(currentColor?.colorLabel).NullOrEmpty())
             {
                 return base.TransformLabel(label) + " (" + currentColor.colorLabel + ")";
             }


### PR DESCRIPTION
`currentColor` is first set on `PostSpawnSetup`
If an Item with this comp is sold via an Orbital Trader, then it is not spawned.
Therefore `currentColor` is `Null`.
This results in the GUI of an Orbital Trader failing when it attempts to get the Label for an Item using this comp.

```
System.NullReferenceException: Object reference not set to an instance of an object
  at VanillaFurnitureExpanded.CompGlowerExtended.TransformLabel (System.String label)
  at Verse.ThingWithComps.get_LabelNoCount ()
  at RimWorld.Tradeable.get_Label ()
  at RimWorld.Dialog_Trade.<CacheTradeables>b__63_2 (RimWorld.Tradeable tr)
  at System.Linq.Utilities+<>c__DisplayClass1_0`1[TSource].<CombinePredicates>b__0 (TSource x)
  at System.Linq.Enumerable+WhereListIterator`1[TSource].ToArray ()
  at System.Linq.Buffer`1[TElement]..ctor (System.Collections.Generic.IEnumerable`1[T] source
  at System.Linq.OrderedEnumerable`1[TElement].ToList ()
  at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source)
  at RimWorld.Dialog_Trade.CacheTradeables ()
  at (wrapper dynamic-method) RimWorld.Dialog_Trade.RimWorld.Dialog_Trade.PostOpen_Patch1(RimWorld.Dialog_Trade)
  at Verse.WindowStack.Add (Verse.Window window)
  at TraderShips.JobDriverTradeWithShip+<>c__DisplayClass3_0.<MakeNewToils>b__1 ()
  at Verse.AI.JobDriver.TryActuallyStartNextToil ()
```