### PR TITLE
Do not reset weather damage options after the game is started

### DIFF
--- a/Source/VFECore/GlobalSettings.cs
+++ b/Source/VFECore/GlobalSettings.cs
@@ -276,7 +276,6 @@ namespace VFECore
     {
         static ModSettingsHandler()
         {
-            VFEGlobal.settings.weatherDamagesOptions = new Dictionary<string, bool>();
             foreach (var weatherDef in DefDatabase<WeatherDef>.AllDefs)
             {
                 var extension = weatherDef.GetModExtension<WeatherEffectsExtension>();


### PR DESCRIPTION
Changes to weather damage options are saved properly and loaded properly, but their values are reset back to true soon after being loaded. This PR prevents these option values from being reset, allowing the game to use the options set previously by the player.

Check this bug report for detailed reproduction steps: https://steamcommunity.com/workshop/filedetails/discussion/2023507013/3130541756140048010/?ctp=38#c3434578410989098979