### PR TITLE
KCSG Gen.Util.cs - "spawnPartofFaction = false" applicable to buildings

### DIFF
--- a/Source/KCSG/Utils/GenUtils.cs
+++ b/Source/KCSG/Utils/GenUtils.cs
@@ -334,7 +334,7 @@ namespace KCSG
             // Spawn the thing
             GenSpawn.Spawn(thing, cell, map, symbol.rotation, WipeMode.VanishOrMoveAside);
             // Set the faction if applicable
-            if (faction != null && thing.def.CanHaveFaction)
+            if (symbol.spawnPartOfFaction != false && faction != null && thing.def.CanHaveFaction)
             {
                 thing.SetFactionDirect(faction);
             }


### PR DESCRIPTION
I've been creating a number of quite massive custom settlements with lots of internal doors between various rooms, creating a labyrinthine-like structures (the player not knowing if there is perhaps a turret or hostile pawns behind a door). However, since all doors spawn claimed by hostile faction, the player needs to manually destroy each and every one in order to enter various rooms, which is troublesome and can sometimes take ages. By adding "spawnPartofFaction = false" to a manually created door SymbolDef, I would be able to generate unclaimed doors inside hostile settlements which can be opened by both player and hostile faction pawns. 